### PR TITLE
Skip if context type is null also

### DIFF
--- a/src/Processors/AugmentProperties.php
+++ b/src/Processors/AugmentProperties.php
@@ -63,7 +63,7 @@ class AugmentProperties
                 continue;
             }
             $comment = str_replace("\r\n", "\n", $context->comment);
-            if ($property->type === UNDEFINED && $context->type !== UNDEFINED) {
+            if ($property->type === UNDEFINED && $context->type && $context->type !== UNDEFINED) {
                 if ($context->nullable === true) {
                     $property->nullable = true;
                 }


### PR DESCRIPTION
Testing this out in a larger project, I ran into a scenario where context type was null, not undefined.