### PR TITLE
properly get array's property name from tokens

### DIFF
--- a/src/StaticAnalyser.php
+++ b/src/StaticAnalyser.php
@@ -407,7 +407,7 @@ class StaticAnalyser
         }
 
         // drill down namespace segments to basename property type declaration
-        while ($token[0] === T_NS_SEPARATOR || $token[0] === T_STRING) {
+        while (in_array($token[0], [T_NS_SEPARATOR, T_STRING, T_ARRAY])) {
             if ($token[0] === T_STRING) {
                 $type = $token[1];
             }

--- a/tests/AugmentPropertiesTest.php
+++ b/tests/AugmentPropertiesTest.php
@@ -21,6 +21,7 @@ class AugmentPropertiesTest extends OpenApiTestCase
 {
     const KEY_PROPERTY = 'property';
     const KEY_REFERENCE = 'ref';
+    const KEY_ITEMS = 'items';
     const KEY_EXAMPLE = 'example';
     const KEY_DESCRIPTION = 'description';
     const KEY_FORMAT = 'format';
@@ -136,6 +137,7 @@ class AugmentPropertiesTest extends OpenApiTestCase
             $stringType,
             $intType,
             $nullableString,
+            $arrayType,
             $dateTime,
             $qualified,
             $namespace,
@@ -160,6 +162,10 @@ class AugmentPropertiesTest extends OpenApiTestCase
             self::KEY_TYPE => UNDEFINED,
         ]);
         $this->assertName($nullableString, [
+            self::KEY_PROPERTY => UNDEFINED,
+            self::KEY_TYPE => UNDEFINED,
+        ]);
+        $this->assertName($arrayType, [
             self::KEY_PROPERTY => UNDEFINED,
             self::KEY_TYPE => UNDEFINED,
         ]);
@@ -230,6 +236,18 @@ class AugmentPropertiesTest extends OpenApiTestCase
             self::KEY_PROPERTY => 'nullableString',
             self::KEY_TYPE => 'string',
         ]);
+        $this->assertName($arrayType, [
+            self::KEY_PROPERTY => 'arrayType',
+            self::KEY_TYPE => 'array',
+        ]);
+        $this->assertObjectHasAttribute(
+            self::KEY_REFERENCE,
+            $arrayType->{self::KEY_ITEMS}
+        );
+        $this->assertEquals(
+            '#/components/schemas/TypedProperties',
+            $arrayType->{self::KEY_ITEMS}->{self::KEY_REFERENCE}
+        );
         $this->assertName($dateTime, [
             self::KEY_PROPERTY => 'dateTime',
             self::KEY_TYPE => 'string',

--- a/tests/Fixtures/TypedProperties.php
+++ b/tests/Fixtures/TypedProperties.php
@@ -27,6 +27,12 @@ class TypedProperties
     public ?string $nullableString;
 
     /**
+     * @var \OpenApiFixtures\TypedProperties[]
+     * @OA\Property()
+     */
+    public array $arrayType;
+
+    /**
      * @OA\Property()
      */
     public DateTime $dateTime;


### PR DESCRIPTION
but don't infer array type